### PR TITLE
Add support for ABGR-4444, 24 bit & 32 bit encodings

### DIFF
--- a/Material.cs
+++ b/Material.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Text;
 using System.IO;
@@ -7,13 +7,154 @@ using System.Drawing.Imaging;
 
 namespace Smith
 {
+    public enum MatColorMode : UInt32
+    {
+        Indexed = 0,
+        RGB     = 1,
+        RGBA    = 2
+    }
+
+    public class ColorFormat
+    {
+        public MatColorMode Mode;
+        public uint Bpp; // bits per pixel
+
+        public uint RedBpp;
+        public uint GreenBpp;
+        public uint BlueBpp;
+
+        public uint RedShl;
+        public uint GreenShl;
+        public uint BlueShl;
+
+        public uint RedShr;
+        public uint GreenShr;
+        public uint BlueShr;
+
+        public uint AlphaBpp;
+        public uint AlphaShl;
+        public uint AlphaShr;
+
+        public ColorFormat() { }
+
+        public ColorFormat(ref BinaryReader br)
+        {
+            Mode = (MatColorMode)br.ReadInt32();
+            Bpp  = br.ReadUInt32();
+
+            RedBpp   = br.ReadUInt32();
+            GreenBpp = br.ReadUInt32();
+            BlueBpp  = br.ReadUInt32();
+
+            RedShl   = br.ReadUInt32();
+            GreenShl = br.ReadUInt32();
+            BlueShl  = br.ReadUInt32();
+
+            RedShr   = br.ReadUInt32();
+            GreenShr = br.ReadUInt32();
+            BlueShr  = br.ReadUInt32();
+
+            AlphaBpp = br.ReadUInt32();
+            AlphaShl = br.ReadUInt32();
+            AlphaShr = br.ReadUInt32();
+        }
+
+        public void Save(ref BinaryWriter bw)
+        {
+            bw.Write((uint)Mode);
+            bw.Write(Bpp);
+
+            bw.Write(RedBpp);
+            bw.Write(GreenBpp);
+            bw.Write(BlueBpp);
+
+            bw.Write(RedShl);
+            bw.Write(GreenShl);
+            bw.Write(BlueShl);
+
+            bw.Write(RedShr);
+            bw.Write(GreenShr);
+            bw.Write(BlueShr);
+
+            bw.Write(AlphaBpp);
+            bw.Write(AlphaShl);
+            bw.Write(AlphaShr);
+        }
+
+        public static readonly ColorFormat Indexed = new ColorFormat()
+        { 
+            Mode = MatColorMode.Indexed,
+            Bpp  = 8,
+
+            RedBpp = 0, GreenBpp = 0, BlueBpp  = 0,
+            RedShl = 0, GreenShl = 0, BlueShl = 0,
+            RedShr = 0, GreenShr = 0, BlueShr = 0,
+            AlphaBpp = 0, AlphaShl = 0, AlphaShr = 0 
+        };
+
+        public static readonly ColorFormat ABGR32 = new ColorFormat()
+        { 
+            Mode = MatColorMode.RGBA,
+            Bpp  = 32,
+
+            RedBpp = 8, GreenBpp = 8, BlueBpp  = 8,
+            RedShl = 24, GreenShl = 16, BlueShl = 8,
+            RedShr = 0, GreenShr = 0, BlueShr = 0,
+            AlphaBpp = 8, AlphaShl = 0, AlphaShr = 0 
+        };
+
+        public static readonly ColorFormat BGR24 = new ColorFormat()
+        {
+            Mode = MatColorMode.RGB,
+            Bpp = 24,
+
+            RedBpp = 8, GreenBpp = 8, BlueBpp = 8,
+            RedShl = 16, GreenShl = 8, BlueShl = 0,
+            RedShr = 0, GreenShr = 0, BlueShr = 0,
+            AlphaBpp = 0, AlphaShl = 0, AlphaShr = 0
+        };
+
+        public static readonly ColorFormat ABGR1555 = new ColorFormat()
+        { 
+            Mode = MatColorMode.RGBA,
+            Bpp  = 16,
+
+            RedBpp = 5, GreenBpp = 5, BlueBpp  = 5,
+            RedShl = 11, GreenShl = 6, BlueShl = 1,
+            RedShr = 3, GreenShr = 3, BlueShr = 3,
+            AlphaBpp = 1, AlphaShl = 0, AlphaShr = 7 
+        };
+
+        public static readonly ColorFormat ABGR4444 = new ColorFormat()
+        { 
+            Mode = MatColorMode.RGBA,
+            Bpp  = 16,
+
+            RedBpp = 4, GreenBpp = 4, BlueBpp  = 4,
+            RedShl = 12, GreenShl = 8, BlueShl = 4,
+            RedShr = 4, GreenShr = 4, BlueShr = 4,
+            AlphaBpp = 4, AlphaShl = 0, AlphaShr = 4 
+        };
+
+        public static readonly ColorFormat BGR565 = new ColorFormat()
+        {
+            Mode = MatColorMode.RGB,
+            Bpp = 16,
+
+            RedBpp = 5, GreenBpp = 6, BlueBpp = 5,
+            RedShl = 11, GreenShl = 5, BlueShl = 0,
+            RedShr = 3, GreenShr = 2, BlueShr = 3,
+            AlphaBpp = 0, AlphaShl = 0, AlphaShr = 0
+        };
+    }
+
     public class Material
     {
         public readonly string Name;
 
-        public const int ColorMaterialSize = 64;
+        public const int ColorMaterialSize = 32;
 
-        public class MaterialHeader
+        public class Record
         {
             public int colorIndex;
             public int textureId;
@@ -29,12 +170,10 @@ namespace Smith
         }
 
         //public int TransparentColor = 0;
-        public int ColorBits = 0;
-        public int BlueBits = 0;
-        public int GreenBits = 0;
-        public int RedBits = 0;
 
-        public List<MaterialHeader> Materials = new List<MaterialHeader>();
+        public ColorFormat format;
+
+        public List<Record> Records = new List<Record>();
         public List<TextureHeader> Textures = new List<TextureHeader>();
 
         public int Width
@@ -61,10 +200,10 @@ namespace Smith
 
         public bool IsSingleColor(int index = 0)
         {
-            if (index < 0 || index >= Materials.Count)
+            if (index < 0 || index >= Records.Count)
                 return false;// whatev
 
-            MaterialHeader mh = Materials[index];
+            Record mh = Records[index];
 
             if (mh.textureId != -1)
                 return false;
@@ -75,17 +214,15 @@ namespace Smith
         public unsafe void GenerateBitmap(out Bitmap bmp, Colormap cmp, out bool failedToNoColormap, bool fillBGForTransparent, int index = 0)
         {
             failedToNoColormap = false;
-
-
             bmp = null;
 
             //if (cmp == null)
             //    return;
 
-            if (index < 0 || index >= Materials.Count)
+            if (index < 0 || index >= Records.Count)
                 return;
 
-            MaterialHeader mh = Materials[index];
+            Record mh = Records[index];
 
             if (mh.textureId == -1)
             {
@@ -117,7 +254,7 @@ namespace Smith
                 return;
 
             bool hasSelfIlluminatedPixels = false;
-            if (ColorBits == 8)
+            if (format.Mode == MatColorMode.Indexed)
             {
                 if (cmp == null)
                 {
@@ -170,7 +307,7 @@ namespace Smith
             BitmapData bmdat = bmp.LockBits(new Rectangle(0, 0, bmp.Width, bmp.Height), ImageLockMode.WriteOnly, PixelFormat.Format32bppArgb);
             fixed (byte* pMipmap = mipmap)
             {
-                if (ColorBits == 8 && cmp != null)
+                if (format.Mode == MatColorMode.Indexed && cmp != null)
                 {
                     // 8-bit palette;  use colormap lookup
                     for (int y = 0; y < bmp.Height; y++)
@@ -194,132 +331,31 @@ namespace Smith
                         }
                     }
                 }
-                else if (ColorBits == 16)
+                else if (format.Mode == MatColorMode.RGB || format.Mode == MatColorMode.RGBA)
                 {
-                    // 16-bit
-
-                    if (GreenBits == 5)
+                    int pixsize = (int)format.Bpp / 8;
+                    int stride  = th.Width * pixsize;
+                    for (int y = 0; y < bmp.Height; y++)
                     {
-                        // 1555 ARGB
-                        for (int y = 0; y < bmp.Height; y++)
+                        byte* pBMPRow = (byte*)((ulong)bmdat.Scan0 + (ulong)(bmdat.Stride * y));
+                        byte* pRow    = pMipmap + y * stride;
+
+                        for (int x = 0; x < bmp.Width; x++)
                         {
-                            byte* pBMPRow = (byte*)((ulong)bmdat.Scan0 + (ulong)(bmdat.Stride * y));
-                            ushort* pMipmapRow = (ushort*)(pMipmap + y * (th.Width * 2));
-
-                            for (int x = 0; x < bmp.Width; x++)
+                            int epix = 0;
+                            switch (pixsize)
                             {
-                                ushort pixelword = pMipmapRow[x];
-
-#if true
-                                // MIGHT BE THE REAL ONE NOW
-
-                                if ((pixelword & 0x8000) != 0)
-                                {
-                                    // opaque
-                                    pBMPRow[x * 4 + 0] = (byte)((double)(pixelword & 0x1F) / (double)0x1F * 255.0);		// blue
-                                    pBMPRow[x * 4 + 1] = (byte)((double)((pixelword >> 5) & 0x1F) / (double)0x1F * 255.0);	// green
-                                    pBMPRow[x * 4 + 2] = (byte)((double)((pixelword >> 10) & 0x1F) / (double)0x1F * 255.0);	// red
-                                    pBMPRow[x * 4 + 3] = 255;                                                           // alpha
-                                }
-                                /*else
-                                {
-                                    // transparent
-                                    pBMPRow[x * 4 + 0] = 0;     // blue
-                                    pBMPRow[x * 4 + 1] = 0;     // green
-                                    pBMPRow[x * 4 + 2] = 0;     // red
-                                    pBMPRow[x * 4 + 3] = 0;     // alpha
-                                }*/
-#elif true
-                                // NEW METHOD;  works for indy
-
-                                if ((pixelword & 0x1) != 0)
-                                {
-                                    // opaque
-                                    pBMPRow[x * 4 + 0] = (byte)((double)((pixelword>>1) & 0x1F) / (double)0x1F * 255.0);		// blue
-                                    pBMPRow[x * 4 + 1] = (byte)((double)((pixelword>>6) & 0x1F) / (double)0x1F * 255.0);	// green
-                                    pBMPRow[x * 4 + 2] = (byte)((double)((pixelword>>11) & 0x1F) / (double)0x1F * 255.0);	// red
-                                    pBMPRow[x * 4 + 3] = 255;                                                           // alpha
-                                }
-                                else
-                                {
-                                    // transparent
-                                    pBMPRow[x * 4 + 0] = 0;     // blue
-                                    pBMPRow[x * 4 + 1] = 0;     // green
-                                    pBMPRow[x * 4 + 2] = 0;     // red
-                                    pBMPRow[x * 4 + 3] = 0;     // alpha
-                                }
-#else
-                                // OLD METHOD;  was in use for JK..  not totally confirmed if correct
-
-                                if ((pixelword & 0x8000) != 0)
-                                {
-                                    // opaque
-                                    pBMPRow[x * 4 + 0] = (byte)((double)(pixelword & 0x1F) / (double)0x1F * 255.0);		// blue
-                                    pBMPRow[x * 4 + 1] = (byte)((double)(pixelword & 0x3E0) / (double)0x3E0 * 255.0);	// green
-                                    pBMPRow[x * 4 + 2] = (byte)((double)(pixelword & 0x7C00) / (double)0x7C00 * 255.0);	// red
-                                    pBMPRow[x * 4 + 3] = 255;                                                           // alpha
-                                }
-                                else
-                                {
-                                    // transparent
-                                    pBMPRow[x * 4 + 0] = 0;     // blue
-                                    pBMPRow[x * 4 + 1] = 0;     // green
-                                    pBMPRow[x * 4 + 2] = 0;     // red
-                                    pBMPRow[x * 4 + 3] = 0;     // alpha
-                                }
-#endif
+                                case 2: epix = *(ushort*)&pRow[x * pixsize]; break;
+                                case 3: epix = (pRow[x * pixsize] | (pRow[x * pixsize + 1] << 8) | (pRow[x * pixsize + 2] << 16)); break;
+                                case 4: epix = *(int*)&pRow[x * pixsize]; break;
                             }
+
+                            var pix = DecodePixel(epix, format);
+                            pBMPRow[x * 4 + 0] = pix.B;
+                            pBMPRow[x * 4 + 1] = pix.G;
+                            pBMPRow[x * 4 + 2] = pix.R;
+                            pBMPRow[x * 4 + 3] = pix.A;
                         }
-                    }
-                    else if (GreenBits == 6)
-                    {
-                        // 565 RGB
-                        for (int y = 0; y < bmp.Height; y++)
-                        {
-                            byte* pBMPRow = (byte*)((ulong)bmdat.Scan0 + (ulong)(bmdat.Stride * y));
-                            ushort* pMipmapRow = (ushort*)(pMipmap + y * (th.Width * 2));
-
-                            for (int x = 0; x < bmp.Width; x++)
-                            {
-                                ushort pixelword = pMipmapRow[x];
-
-#if true
-                                pBMPRow[x * 4 + 0] = (byte)((pixelword & 0x1F) * 255 / 0x1F);	        // blue
-                                pBMPRow[x * 4 + 1] = (byte)(((pixelword >> 5) & 0x3F) * 255 / 0x3F);	// green
-                                pBMPRow[x * 4 + 2] = (byte)(((pixelword >> 11) & 0x1F) * 255 / 0x1F); 	// red
-                                pBMPRow[x * 4 + 3] = 255;                                               // alpha
-#else
-
-                                pBMPRow[x * 4 + 0] = (byte)((double)(pixelword & 0x1F) / (double)0x1F * 255.0);		// blue
-                                pBMPRow[x * 4 + 1] = (byte)((double)(pixelword & 0x7E0) / (double)0x7E0 * 255.0);	// green
-                                pBMPRow[x * 4 + 2] = (byte)((double)(pixelword & 0xF800) / (double)0xF800 * 255.0);	// red
-                                pBMPRow[x * 4 + 3] = 255;                                                           // alpha
-#endif
-                            }
-                        }
-                    }
-                    else if (GreenBits == 4)
-                    {
-                        // 4444 RGBA
-                        for (int y = 0; y < bmp.Height; y++)
-                        {
-                            byte* pBMPRow = (byte*)((ulong)bmdat.Scan0 + (ulong)(bmdat.Stride * y));
-                            ushort* pMipmapRow = (ushort*)(pMipmap + y * (th.Width * 2));
-
-                            for (int x = 0; x < bmp.Width; x++)
-                            {
-                                ushort pixelword = pMipmapRow[x];
-
-                                pBMPRow[x * 4 + 0] = (byte)(((pixelword>>4) & 0xF) * 255 / 0xF);	    // blue
-                                pBMPRow[x * 4 + 1] = (byte)(((pixelword >> 8) & 0xF) * 255 / 0xF);	    // green
-                                pBMPRow[x * 4 + 2] = (byte)(((pixelword >> 12) & 0xF) * 255 / 0xF); 	// red
-                                pBMPRow[x * 4 + 3] = (byte)((pixelword & 0xF) * 255 / 0xF);             // alpha
-                            }
-                        }
-                    }
-                    else
-                    {
-                        //Log.Error($"Unsupported 16-bit mat channel configuration {RedBits}{GreenBits}{BlueBits}");
                     }
                 }
                 else
@@ -353,38 +389,13 @@ namespace Smith
             bw.Write((byte)' ');
             bw.Write(0x32); // ver
             bw.Write(2);    // type
-            bw.Write(Materials.Count);    // nummaterials
+            bw.Write(Records.Count);    // nummaterials
             bw.Write(Textures.Count);    // numtextures
-            bw.Write(ColorBits > 8 ? 1 : 0);    // is16bit
-            bw.Write(ColorBits);    // colorbits
-            bw.Write(BlueBits);    // bluebits
-            bw.Write(GreenBits);    // greenbits
-            bw.Write(RedBits);    // redbits
 
-            // for paletted these are all 0?
-            if (ColorBits == 8)
-            {
-                bw.Write(0);// unknown
-                bw.Write(0);//unknown
-                bw.Write(0);//unknown
-                bw.Write(0);//unknown
-                bw.Write(0);//unknown
-                bw.Write(0);//unknown
-            }
-            else
-            {
-                bw.Write(0x0B);// unknown
-                bw.Write(0x05);//unknown
-                bw.Write(0);//unknown
-                bw.Write(0x03);//unknown
-                bw.Write(0x02);//unknown
-                bw.Write(0x03);//unknown
-            }
-            for (int x = 0; x < 3 * 4; x++)
-                bw.Write((byte)0);
+            format.Save(ref bw);
 
             int texIndex = 0;
-            foreach(MaterialHeader mh in Materials)
+            foreach(Record mh in Records)
             {
                 bw.Write(8);    // texture
 
@@ -433,42 +444,18 @@ namespace Smith
         {
             Name = n;
 
-
             BinaryReader br = new BinaryReader(s);
 
             br.ReadBytes(8);
 
             int type = br.ReadInt32();
-            int numMaterials = br.ReadInt32();
+            int numRecords  = br.ReadInt32();
             int numTextures = br.ReadInt32();
-            int is16bit = br.ReadInt32();
-            ColorBits = br.ReadInt32();
-            BlueBits = br.ReadInt32();
-            GreenBits = br.ReadInt32();
-            RedBits = br.ReadInt32();
-            br.ReadBytes(36);
+            format = new ColorFormat(ref br);
 
-            // JKPaint support
-            if (ColorBits == 16 && RedBits == 0 && GreenBits == 0 && BlueBits == 0)
+            for (int x = 0; x < numRecords; x++)
             {
-                // DUNNO
-                if (is16bit == 1)
-                {
-                    RedBits = 5;
-                    GreenBits = 6;
-                    BlueBits = 5;
-                }
-                else
-                {
-                    RedBits = 5;
-                    GreenBits = 5;
-                    BlueBits = 5;
-                }
-            }
-
-            for (int x = 0; x < numMaterials; x++)
-            {
-                MaterialHeader m = new MaterialHeader();
+                Record m = new Record();
 
                 int mtype = br.ReadInt32();
                 m.colorIndex = br.ReadInt32();
@@ -482,7 +469,7 @@ namespace Smith
                 else
                     m.textureId = -1;
 
-                Materials.Add(m);
+                Records.Add(m);
             }
 
             for (int x = 0; x < numTextures; x++)
@@ -495,8 +482,8 @@ namespace Smith
                 br.ReadBytes(4);
                 t.TransparentColorNum = br.ReadInt32();
 
-                int mipmapBufSize = (t.Width * t.Height * ColorBits) / 8;
-                int numMipmaps = br.ReadInt32();
+                int mipmapBufSize = (t.Width * t.Height * (int)format.Bpp) / 8;
+                int numMipmaps    = br.ReadInt32();
                 for (int y = 0; y < numMipmaps; y++)
                 {
                     t.MipmapData.Add(br.ReadBytes(mipmapBufSize));
@@ -505,6 +492,41 @@ namespace Smith
 
                 Textures.Add(t);
             }
+        }
+        static uint GetColorMask(uint bpc)
+        {
+            return 0xFFFFFFFF >> (32 - (int)bpc);
+        }
+
+        public static Color DecodePixel(int p, ColorFormat cf)
+        {
+            int r = ((p >> (int)cf.RedShl) & (int)GetColorMask(cf.RedBpp)) << (int)cf.RedShr;
+            int g = ((p >> (int)cf.GreenShl) & (int)GetColorMask(cf.GreenBpp)) << (int)cf.GreenShr;
+            int b = ((p >> (int)cf.BlueShl) & (int)GetColorMask(cf.BlueBpp)) << (int)cf.BlueShr;
+            int a = 255;
+            if (cf.AlphaBpp > 0)
+            {
+                a = ((p >> (int)cf.AlphaShl) & (int)GetColorMask(cf.AlphaBpp)) << (int)cf.AlphaShr;
+                if (cf.AlphaBpp == 1) // RGB5551
+                {
+                    a = a > 0 ? 255 : 0;
+                }
+            }
+            return Color.FromArgb(a, r, g, b);
+        }
+
+        public static int EncodePixel(Color p, ColorFormat cf)
+        {
+            int ep =
+            ((p.R >> (int)cf.RedShr) << (int)cf.RedShl) |
+            ((p.G >> (int)cf.GreenShr) << (int)cf.GreenShl) |
+            ((p.B >> (int)cf.BlueShr) << (int)cf.BlueShl);
+
+            if (cf.AlphaBpp != 0)
+            {
+                ep |= (p.A >> (int)cf.AlphaShr) << (int)cf.AlphaShl;
+            }
+            return ep;
         }
     }
 }

--- a/Material.cs
+++ b/Material.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Text;
 using System.IO;
@@ -24,6 +24,7 @@ namespace Smith
             public int Width;
             public int Height;
             public bool Transparent;
+            public int TransparentColorNum;
             public List<byte[]> MipmapData = new List<byte[]>();
         }
 
@@ -182,11 +183,10 @@ namespace Smith
                             byte b = pMipmapRow[x];
 
                             // if transparent pixel;  we have already filled the background
-                            if(th.Transparent && b == 0/*color key?  or just 0*/)
+                            if (th.Transparent && b == th.TransparentColorNum) // guess based on OpenJKDF2 source code
                                 continue;
 
                             Colormap.RGB rgb = cmp.Palette[b];
-
                             pBMPRow[x * 4 + 0] = rgb.B;     // blue
                             pBMPRow[x * 4 + 1] = rgb.G;     // green
                             pBMPRow[x * 4 + 2] = rgb.R;     // red
@@ -418,7 +418,7 @@ namespace Smith
                 bw.Write(th.Height);
                 bw.Write(th.Transparent?1:0/*should be color value?*/);    // transparent
                 bw.Write(0);    // pad
-                bw.Write(0);    // pad
+                bw.Write(th.TransparentColorNum);
                 bw.Write(th.MipmapData.Count);    // mipmaps
 
                 // dump mips
@@ -492,7 +492,8 @@ namespace Smith
                 t.Width = br.ReadInt32();
                 t.Height = br.ReadInt32();
                 t.Transparent = (br.ReadInt32() != 0);
-                br.ReadBytes(8);
+                br.ReadBytes(4);
+                t.TransparentColorNum = br.ReadInt32();
 
                 int mipmapBufSize = (t.Width * t.Height * ColorBits) / 8;
                 int numMipmaps = br.ReadInt32();

--- a/Matt.Designer.cs
+++ b/Matt.Designer.cs
@@ -1,4 +1,4 @@
-﻿namespace Matt
+namespace Matt
 {
     partial class Matt
     {
@@ -28,15 +28,15 @@
         /// </summary>
         private void InitializeComponent()
         {
-            this.pictureBox1 = new MattControls.PictureBoxMaterial();
             this.label1 = new System.Windows.Forms.Label();
             this.label2 = new System.Windows.Forms.Label();
-            this.pictureBox2 = new MattControls.PictureBoxMaterial();
             this.groupBox2 = new System.Windows.Forms.GroupBox();
+            this.abgr32 = new System.Windows.Forms.RadioButton();
+            this.bgr24 = new System.Windows.Forms.RadioButton();
             this.bitdepthSolid = new System.Windows.Forms.RadioButton();
-            this.bitdepth4444 = new System.Windows.Forms.RadioButton();
-            this.bitdepth1555 = new System.Windows.Forms.RadioButton();
-            this.bitdepth565 = new System.Windows.Forms.RadioButton();
+            this.abgr4444 = new System.Windows.Forms.RadioButton();
+            this.abgr1555 = new System.Windows.Forms.RadioButton();
+            this.bgr565 = new System.Windows.Forms.RadioButton();
             this.bitdepth8 = new System.Windows.Forms.RadioButton();
             this.colormapGroup = new System.Windows.Forms.GroupBox();
             this.pictureBox3 = new System.Windows.Forms.PictureBox();
@@ -54,8 +54,8 @@
             this.logList = new System.Windows.Forms.ListBox();
             this.autoselectFormat = new System.Windows.Forms.CheckBox();
             this.splitContainer1 = new System.Windows.Forms.SplitContainer();
-            ((System.ComponentModel.ISupportInitialize)(this.pictureBox1)).BeginInit();
-            ((System.ComponentModel.ISupportInitialize)(this.pictureBox2)).BeginInit();
+            this.pictureBox1 = new MattControls.PictureBoxMaterial();
+            this.pictureBox2 = new MattControls.PictureBoxMaterial();
             this.groupBox2.SuspendLayout();
             this.colormapGroup.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.pictureBox3)).BeginInit();
@@ -63,120 +63,131 @@
             this.splitContainer1.Panel1.SuspendLayout();
             this.splitContainer1.Panel2.SuspendLayout();
             this.splitContainer1.SuspendLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.pictureBox1)).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)(this.pictureBox2)).BeginInit();
             this.SuspendLayout();
-            // 
-            // pictureBox1
-            // 
-            this.pictureBox1.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
-            | System.Windows.Forms.AnchorStyles.Left) 
-            | System.Windows.Forms.AnchorStyles.Right)));
-            this.pictureBox1.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
-            this.pictureBox1.Location = new System.Drawing.Point(6, 20);
-            this.pictureBox1.Name = "pictureBox1";
-            this.pictureBox1.Size = new System.Drawing.Size(257, 243);
-            this.pictureBox1.SizeMode = System.Windows.Forms.PictureBoxSizeMode.Zoom;
-            this.pictureBox1.TabIndex = 0;
-            this.pictureBox1.TabStop = false;
             // 
             // label1
             // 
             this.label1.AutoSize = true;
-            this.label1.Location = new System.Drawing.Point(3, 4);
+            this.label1.Location = new System.Drawing.Point(4, 5);
+            this.label1.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.label1.Name = "label1";
-            this.label1.Size = new System.Drawing.Size(42, 13);
+            this.label1.Size = new System.Drawing.Size(53, 16);
             this.label1.TabIndex = 1;
             this.label1.Text = "Original";
             // 
             // label2
             // 
             this.label2.AutoSize = true;
-            this.label2.Location = new System.Drawing.Point(3, 4);
+            this.label2.Location = new System.Drawing.Point(4, 5);
+            this.label2.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.label2.Name = "label2";
-            this.label2.Size = new System.Drawing.Size(45, 13);
+            this.label2.Size = new System.Drawing.Size(55, 16);
             this.label2.TabIndex = 3;
             this.label2.Text = "Preview";
-            // 
-            // pictureBox2
-            // 
-            this.pictureBox2.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
-            | System.Windows.Forms.AnchorStyles.Left) 
-            | System.Windows.Forms.AnchorStyles.Right)));
-            this.pictureBox2.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
-            this.pictureBox2.Location = new System.Drawing.Point(6, 20);
-            this.pictureBox2.Name = "pictureBox2";
-            this.pictureBox2.Size = new System.Drawing.Size(254, 243);
-            this.pictureBox2.SizeMode = System.Windows.Forms.PictureBoxSizeMode.Zoom;
-            this.pictureBox2.TabIndex = 2;
-            this.pictureBox2.TabStop = false;
             // 
             // groupBox2
             // 
             this.groupBox2.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
+            this.groupBox2.Controls.Add(this.abgr32);
+            this.groupBox2.Controls.Add(this.bgr24);
             this.groupBox2.Controls.Add(this.bitdepthSolid);
-            this.groupBox2.Controls.Add(this.bitdepth4444);
-            this.groupBox2.Controls.Add(this.bitdepth1555);
-            this.groupBox2.Controls.Add(this.bitdepth565);
+            this.groupBox2.Controls.Add(this.abgr4444);
+            this.groupBox2.Controls.Add(this.abgr1555);
+            this.groupBox2.Controls.Add(this.bgr565);
             this.groupBox2.Controls.Add(this.bitdepth8);
-            this.groupBox2.Location = new System.Drawing.Point(551, 12);
+            this.groupBox2.Location = new System.Drawing.Point(738, 13);
+            this.groupBox2.Margin = new System.Windows.Forms.Padding(4);
             this.groupBox2.Name = "groupBox2";
-            this.groupBox2.Size = new System.Drawing.Size(237, 164);
+            this.groupBox2.Padding = new System.Windows.Forms.Padding(4);
+            this.groupBox2.Size = new System.Drawing.Size(316, 217);
             this.groupBox2.TabIndex = 5;
             this.groupBox2.TabStop = false;
             this.groupBox2.Text = "Material Format";
             // 
+            // abgr32
+            // 
+            this.abgr32.AutoSize = true;
+            this.abgr32.Location = new System.Drawing.Point(8, 193);
+            this.abgr32.Margin = new System.Windows.Forms.Padding(4);
+            this.abgr32.Name = "abgr32";
+            this.abgr32.Size = new System.Drawing.Size(60, 20);
+            this.abgr32.TabIndex = 6;
+            this.abgr32.Text = "32-bit";
+            this.abgr32.UseVisualStyleBackColor = true;
+            this.abgr32.CheckedChanged += new System.EventHandler(this.format_CheckedChanged);
+            // 
+            // bgr24
+            // 
+            this.bgr24.AutoSize = true;
+            this.bgr24.Location = new System.Drawing.Point(8, 165);
+            this.bgr24.Margin = new System.Windows.Forms.Padding(4);
+            this.bgr24.Name = "bgr24";
+            this.bgr24.Size = new System.Drawing.Size(60, 20);
+            this.bgr24.TabIndex = 5;
+            this.bgr24.Text = "24-bit";
+            this.bgr24.UseVisualStyleBackColor = true;
+            this.bgr24.CheckedChanged += new System.EventHandler(this.format_CheckedChanged);
+            // 
             // bitdepthSolid
             // 
             this.bitdepthSolid.AutoSize = true;
-            this.bitdepthSolid.Location = new System.Drawing.Point(6, 19);
+            this.bitdepthSolid.Location = new System.Drawing.Point(8, 23);
+            this.bitdepthSolid.Margin = new System.Windows.Forms.Padding(4);
             this.bitdepthSolid.Name = "bitdepthSolid";
-            this.bitdepthSolid.Size = new System.Drawing.Size(136, 17);
+            this.bitdepthSolid.Size = new System.Drawing.Size(168, 20);
             this.bitdepthSolid.TabIndex = 4;
             this.bitdepthSolid.Text = "Solid color w/ colormap";
             this.bitdepthSolid.UseVisualStyleBackColor = true;
             this.bitdepthSolid.Visible = false;
             this.bitdepthSolid.CheckedChanged += new System.EventHandler(this.format_CheckedChanged);
             // 
-            // bitdepth4444
+            // abgr4444
             // 
-            this.bitdepth4444.AutoSize = true;
-            this.bitdepth4444.Location = new System.Drawing.Point(6, 111);
-            this.bitdepth4444.Name = "bitdepth4444";
-            this.bitdepth4444.Size = new System.Drawing.Size(159, 17);
-            this.bitdepth4444.TabIndex = 3;
-            this.bitdepth4444.Text = "16-bit 4444ARGB (Indy only)";
-            this.bitdepth4444.UseVisualStyleBackColor = true;
-            this.bitdepth4444.CheckedChanged += new System.EventHandler(this.format_CheckedChanged);
+            this.abgr4444.AutoSize = true;
+            this.abgr4444.Location = new System.Drawing.Point(8, 137);
+            this.abgr4444.Margin = new System.Windows.Forms.Padding(4);
+            this.abgr4444.Name = "abgr4444";
+            this.abgr4444.Size = new System.Drawing.Size(129, 20);
+            this.abgr4444.TabIndex = 3;
+            this.abgr4444.Text = "16-bit 4444ABGR";
+            this.abgr4444.UseVisualStyleBackColor = true;
+            this.abgr4444.CheckedChanged += new System.EventHandler(this.format_CheckedChanged);
             // 
-            // bitdepth1555
+            // abgr1555
             // 
-            this.bitdepth1555.AutoSize = true;
-            this.bitdepth1555.Location = new System.Drawing.Point(6, 88);
-            this.bitdepth1555.Name = "bitdepth1555";
-            this.bitdepth1555.Size = new System.Drawing.Size(108, 17);
-            this.bitdepth1555.TabIndex = 2;
-            this.bitdepth1555.Text = "16-bit 1555ARGB";
-            this.bitdepth1555.UseVisualStyleBackColor = true;
-            this.bitdepth1555.CheckedChanged += new System.EventHandler(this.format_CheckedChanged);
+            this.abgr1555.AutoSize = true;
+            this.abgr1555.Location = new System.Drawing.Point(8, 108);
+            this.abgr1555.Margin = new System.Windows.Forms.Padding(4);
+            this.abgr1555.Name = "abgr1555";
+            this.abgr1555.Size = new System.Drawing.Size(129, 20);
+            this.abgr1555.TabIndex = 2;
+            this.abgr1555.Text = "16-bit 1555ABGR";
+            this.abgr1555.UseVisualStyleBackColor = true;
+            this.abgr1555.CheckedChanged += new System.EventHandler(this.format_CheckedChanged);
             // 
-            // bitdepth565
+            // bgr565
             // 
-            this.bitdepth565.AutoSize = true;
-            this.bitdepth565.Checked = true;
-            this.bitdepth565.Location = new System.Drawing.Point(6, 65);
-            this.bitdepth565.Name = "bitdepth565";
-            this.bitdepth565.Size = new System.Drawing.Size(95, 17);
-            this.bitdepth565.TabIndex = 1;
-            this.bitdepth565.TabStop = true;
-            this.bitdepth565.Text = "16-bit 565RGB";
-            this.bitdepth565.UseVisualStyleBackColor = true;
-            this.bitdepth565.CheckedChanged += new System.EventHandler(this.format_CheckedChanged);
+            this.bgr565.AutoSize = true;
+            this.bgr565.Checked = true;
+            this.bgr565.Location = new System.Drawing.Point(8, 80);
+            this.bgr565.Margin = new System.Windows.Forms.Padding(4);
+            this.bgr565.Name = "bgr565";
+            this.bgr565.Size = new System.Drawing.Size(113, 20);
+            this.bgr565.TabIndex = 1;
+            this.bgr565.TabStop = true;
+            this.bgr565.Text = "16-bit 565BGR";
+            this.bgr565.UseVisualStyleBackColor = true;
+            this.bgr565.CheckedChanged += new System.EventHandler(this.format_CheckedChanged);
             // 
             // bitdepth8
             // 
             this.bitdepth8.AutoSize = true;
-            this.bitdepth8.Location = new System.Drawing.Point(6, 42);
+            this.bitdepth8.Location = new System.Drawing.Point(8, 52);
+            this.bitdepth8.Margin = new System.Windows.Forms.Padding(4);
             this.bitdepth8.Name = "bitdepth8";
-            this.bitdepth8.Size = new System.Drawing.Size(107, 17);
+            this.bitdepth8.Size = new System.Drawing.Size(129, 20);
             this.bitdepth8.TabIndex = 0;
             this.bitdepth8.Text = "8-bit w/ colormap";
             this.bitdepth8.UseVisualStyleBackColor = true;
@@ -192,9 +203,11 @@
             this.colormapGroup.Controls.Add(this.cmpOrGobPath);
             this.colormapGroup.Controls.Add(this.label3);
             this.colormapGroup.Controls.Add(this.gobColormap);
-            this.colormapGroup.Location = new System.Drawing.Point(551, 182);
+            this.colormapGroup.Location = new System.Drawing.Point(735, 238);
+            this.colormapGroup.Margin = new System.Windows.Forms.Padding(4);
             this.colormapGroup.Name = "colormapGroup";
-            this.colormapGroup.Size = new System.Drawing.Size(237, 256);
+            this.colormapGroup.Padding = new System.Windows.Forms.Padding(4);
+            this.colormapGroup.Size = new System.Drawing.Size(316, 313);
             this.colormapGroup.TabIndex = 7;
             this.colormapGroup.TabStop = false;
             this.colormapGroup.Text = "Colormap";
@@ -202,9 +215,9 @@
             // pictureBox3
             // 
             this.pictureBox3.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
-            this.pictureBox3.Location = new System.Drawing.Point(6, 113);
+            this.pictureBox3.Location = new System.Drawing.Point(8, 130);
             this.pictureBox3.Name = "pictureBox3";
-            this.pictureBox3.Size = new System.Drawing.Size(225, 137);
+            this.pictureBox3.Size = new System.Drawing.Size(301, 176);
             this.pictureBox3.TabIndex = 5;
             this.pictureBox3.TabStop = false;
             this.pictureBox3.Paint += new System.Windows.Forms.PaintEventHandler(this.colormap_Paint);
@@ -212,17 +225,19 @@
             // label4
             // 
             this.label4.AutoSize = true;
-            this.label4.Location = new System.Drawing.Point(6, 70);
+            this.label4.Location = new System.Drawing.Point(8, 79);
+            this.label4.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.label4.Name = "label4";
-            this.label4.Size = new System.Drawing.Size(77, 13);
+            this.label4.Size = new System.Drawing.Size(98, 16);
             this.label4.TabIndex = 4;
             this.label4.Text = "GOB Colormap";
             // 
             // button2
             // 
-            this.button2.Location = new System.Drawing.Point(156, 30);
+            this.button2.Location = new System.Drawing.Point(208, 37);
+            this.button2.Margin = new System.Windows.Forms.Padding(4);
             this.button2.Name = "button2";
-            this.button2.Size = new System.Drawing.Size(75, 23);
+            this.button2.Size = new System.Drawing.Size(100, 26);
             this.button2.TabIndex = 3;
             this.button2.Text = "Browse";
             this.button2.UseVisualStyleBackColor = true;
@@ -230,18 +245,20 @@
             // 
             // cmpOrGobPath
             // 
-            this.cmpOrGobPath.Location = new System.Drawing.Point(6, 32);
+            this.cmpOrGobPath.Location = new System.Drawing.Point(8, 39);
+            this.cmpOrGobPath.Margin = new System.Windows.Forms.Padding(4);
             this.cmpOrGobPath.Name = "cmpOrGobPath";
-            this.cmpOrGobPath.Size = new System.Drawing.Size(144, 20);
+            this.cmpOrGobPath.Size = new System.Drawing.Size(191, 22);
             this.cmpOrGobPath.TabIndex = 2;
             this.cmpOrGobPath.TextChanged += new System.EventHandler(this.textBox1_TextChanged);
             // 
             // label3
             // 
             this.label3.AutoSize = true;
-            this.label3.Location = new System.Drawing.Point(6, 16);
+            this.label3.Location = new System.Drawing.Point(8, 20);
+            this.label3.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.label3.Name = "label3";
-            this.label3.Size = new System.Drawing.Size(81, 13);
+            this.label3.Size = new System.Drawing.Size(99, 16);
             this.label3.TabIndex = 1;
             this.label3.Text = "*.cmp OR *.gob";
             // 
@@ -250,17 +267,19 @@
             this.gobColormap.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
             this.gobColormap.Enabled = false;
             this.gobColormap.FormattingEnabled = true;
-            this.gobColormap.Location = new System.Drawing.Point(6, 86);
+            this.gobColormap.Location = new System.Drawing.Point(8, 99);
+            this.gobColormap.Margin = new System.Windows.Forms.Padding(4);
             this.gobColormap.Name = "gobColormap";
-            this.gobColormap.Size = new System.Drawing.Size(144, 21);
+            this.gobColormap.Size = new System.Drawing.Size(191, 24);
             this.gobColormap.TabIndex = 0;
             this.gobColormap.SelectedIndexChanged += new System.EventHandler(this.gobColormap_SelectedIndexChanged);
             // 
             // openButton
             // 
-            this.openButton.Location = new System.Drawing.Point(12, 12);
+            this.openButton.Location = new System.Drawing.Point(16, 15);
+            this.openButton.Margin = new System.Windows.Forms.Padding(4);
             this.openButton.Name = "openButton";
-            this.openButton.Size = new System.Drawing.Size(75, 23);
+            this.openButton.Size = new System.Drawing.Size(100, 28);
             this.openButton.TabIndex = 8;
             this.openButton.Text = "Open...";
             this.openButton.UseVisualStyleBackColor = true;
@@ -268,9 +287,10 @@
             // 
             // saveButton
             // 
-            this.saveButton.Location = new System.Drawing.Point(12, 41);
+            this.saveButton.Location = new System.Drawing.Point(16, 50);
+            this.saveButton.Margin = new System.Windows.Forms.Padding(4);
             this.saveButton.Name = "saveButton";
-            this.saveButton.Size = new System.Drawing.Size(75, 23);
+            this.saveButton.Size = new System.Drawing.Size(100, 28);
             this.saveButton.TabIndex = 9;
             this.saveButton.Text = "Save...";
             this.saveButton.UseVisualStyleBackColor = true;
@@ -278,9 +298,10 @@
             // 
             // originalKeepColormap
             // 
-            this.originalKeepColormap.Location = new System.Drawing.Point(12, 140);
+            this.originalKeepColormap.Location = new System.Drawing.Point(16, 172);
+            this.originalKeepColormap.Margin = new System.Windows.Forms.Padding(4);
             this.originalKeepColormap.Name = "originalKeepColormap";
-            this.originalKeepColormap.Size = new System.Drawing.Size(136, 23);
+            this.originalKeepColormap.Size = new System.Drawing.Size(181, 28);
             this.originalKeepColormap.TabIndex = 10;
             this.originalKeepColormap.Text = "Keep Current Colormap";
             this.originalKeepColormap.UseVisualStyleBackColor = true;
@@ -291,9 +312,10 @@
             this.originalNeedColormap.AutoSize = true;
             this.originalNeedColormap.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.originalNeedColormap.ForeColor = System.Drawing.Color.DarkOrange;
-            this.originalNeedColormap.Location = new System.Drawing.Point(145, 4);
+            this.originalNeedColormap.Location = new System.Drawing.Point(193, 5);
+            this.originalNeedColormap.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.originalNeedColormap.Name = "originalNeedColormap";
-            this.originalNeedColormap.Size = new System.Drawing.Size(113, 13);
+            this.originalNeedColormap.Size = new System.Drawing.Size(141, 17);
             this.originalNeedColormap.TabIndex = 11;
             this.originalNeedColormap.Text = "NEED COLORMAP";
             this.originalNeedColormap.Visible = false;
@@ -303,9 +325,10 @@
             this.previewNeedColormap.AutoSize = true;
             this.previewNeedColormap.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.previewNeedColormap.ForeColor = System.Drawing.Color.DarkOrange;
-            this.previewNeedColormap.Location = new System.Drawing.Point(152, 4);
+            this.previewNeedColormap.Location = new System.Drawing.Point(203, 5);
+            this.previewNeedColormap.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.previewNeedColormap.Name = "previewNeedColormap";
-            this.previewNeedColormap.Size = new System.Drawing.Size(113, 13);
+            this.previewNeedColormap.Size = new System.Drawing.Size(141, 17);
             this.previewNeedColormap.TabIndex = 12;
             this.previewNeedColormap.Text = "NEED COLORMAP";
             this.previewNeedColormap.Visible = false;
@@ -315,9 +338,10 @@
             this.fillTransparent.AutoSize = true;
             this.fillTransparent.Checked = true;
             this.fillTransparent.CheckState = System.Windows.Forms.CheckState.Checked;
-            this.fillTransparent.Location = new System.Drawing.Point(337, 18);
+            this.fillTransparent.Location = new System.Drawing.Point(449, 22);
+            this.fillTransparent.Margin = new System.Windows.Forms.Padding(4);
             this.fillTransparent.Name = "fillTransparent";
-            this.fillTransparent.Size = new System.Drawing.Size(160, 17);
+            this.fillTransparent.Size = new System.Drawing.Size(195, 20);
             this.fillTransparent.TabIndex = 13;
             this.fillTransparent.Text = "Show transparent as fuchsia";
             this.fillTransparent.UseVisualStyleBackColor = true;
@@ -326,10 +350,12 @@
             // logList
             // 
             this.logList.FormattingEnabled = true;
-            this.logList.Location = new System.Drawing.Point(114, 12);
+            this.logList.ItemHeight = 16;
+            this.logList.Location = new System.Drawing.Point(152, 15);
+            this.logList.Margin = new System.Windows.Forms.Padding(4);
             this.logList.Name = "logList";
             this.logList.SelectionMode = System.Windows.Forms.SelectionMode.None;
-            this.logList.Size = new System.Drawing.Size(217, 121);
+            this.logList.Size = new System.Drawing.Size(288, 148);
             this.logList.TabIndex = 14;
             // 
             // autoselectFormat
@@ -337,9 +363,10 @@
             this.autoselectFormat.AutoSize = true;
             this.autoselectFormat.Checked = true;
             this.autoselectFormat.CheckState = System.Windows.Forms.CheckState.Checked;
-            this.autoselectFormat.Location = new System.Drawing.Point(337, 41);
+            this.autoselectFormat.Location = new System.Drawing.Point(449, 50);
+            this.autoselectFormat.Margin = new System.Windows.Forms.Padding(4);
             this.autoselectFormat.Name = "autoselectFormat";
-            this.autoselectFormat.Size = new System.Drawing.Size(212, 17);
+            this.autoselectFormat.Size = new System.Drawing.Size(264, 20);
             this.autoselectFormat.TabIndex = 15;
             this.autoselectFormat.Text = "Autoselect format based on input image";
             this.autoselectFormat.UseVisualStyleBackColor = true;
@@ -349,7 +376,8 @@
             this.splitContainer1.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
             | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
-            this.splitContainer1.Location = new System.Drawing.Point(12, 169);
+            this.splitContainer1.Location = new System.Drawing.Point(16, 208);
+            this.splitContainer1.Margin = new System.Windows.Forms.Padding(4);
             this.splitContainer1.Name = "splitContainer1";
             // 
             // splitContainer1.Panel1
@@ -363,16 +391,43 @@
             this.splitContainer1.Panel2.Controls.Add(this.label2);
             this.splitContainer1.Panel2.Controls.Add(this.pictureBox2);
             this.splitContainer1.Panel2.Controls.Add(this.previewNeedColormap);
-            this.splitContainer1.Size = new System.Drawing.Size(533, 269);
-            this.splitContainer1.SplitterDistance = 266;
+            this.splitContainer1.Size = new System.Drawing.Size(711, 343);
+            this.splitContainer1.SplitterDistance = 354;
+            this.splitContainer1.SplitterWidth = 5;
             this.splitContainer1.TabIndex = 16;
+            // 
+            // pictureBox1
+            // 
+            this.pictureBox1.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
+            | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
+            this.pictureBox1.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
+            this.pictureBox1.Location = new System.Drawing.Point(6, 30);
+            this.pictureBox1.Name = "pictureBox1";
+            this.pictureBox1.Size = new System.Drawing.Size(345, 310);
+            this.pictureBox1.SizeMode = System.Windows.Forms.PictureBoxSizeMode.Zoom;
+            this.pictureBox1.TabIndex = 0;
+            this.pictureBox1.TabStop = false;
+            // 
+            // pictureBox2
+            // 
+            this.pictureBox2.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
+            | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
+            this.pictureBox2.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
+            this.pictureBox2.Location = new System.Drawing.Point(6, 30);
+            this.pictureBox2.Name = "pictureBox2";
+            this.pictureBox2.Size = new System.Drawing.Size(342, 310);
+            this.pictureBox2.SizeMode = System.Windows.Forms.PictureBoxSizeMode.Zoom;
+            this.pictureBox2.TabIndex = 2;
+            this.pictureBox2.TabStop = false;
             // 
             // Matt
             // 
             this.AllowDrop = true;
-            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
+            this.AutoScaleDimensions = new System.Drawing.SizeF(8F, 16F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            this.ClientSize = new System.Drawing.Size(800, 450);
+            this.ClientSize = new System.Drawing.Size(1067, 566);
             this.Controls.Add(this.splitContainer1);
             this.Controls.Add(this.autoselectFormat);
             this.Controls.Add(this.logList);
@@ -382,6 +437,7 @@
             this.Controls.Add(this.openButton);
             this.Controls.Add(this.colormapGroup);
             this.Controls.Add(this.groupBox2);
+            this.Margin = new System.Windows.Forms.Padding(4);
             this.Name = "Matt";
             this.Text = "Matt - BAH 2021";
             this.FormClosing += new System.Windows.Forms.FormClosingEventHandler(this.Matt_FormClosing);
@@ -389,8 +445,6 @@
             this.Load += new System.EventHandler(this.Matt_Load);
             this.DragDrop += new System.Windows.Forms.DragEventHandler(this.Matt_DragDrop);
             this.DragEnter += new System.Windows.Forms.DragEventHandler(this.Matt_DragEnter);
-            ((System.ComponentModel.ISupportInitialize)(this.pictureBox1)).EndInit();
-            ((System.ComponentModel.ISupportInitialize)(this.pictureBox2)).EndInit();
             this.groupBox2.ResumeLayout(false);
             this.groupBox2.PerformLayout();
             this.colormapGroup.ResumeLayout(false);
@@ -402,6 +456,8 @@
             this.splitContainer1.Panel2.PerformLayout();
             ((System.ComponentModel.ISupportInitialize)(this.splitContainer1)).EndInit();
             this.splitContainer1.ResumeLayout(false);
+            ((System.ComponentModel.ISupportInitialize)(this.pictureBox1)).EndInit();
+            ((System.ComponentModel.ISupportInitialize)(this.pictureBox2)).EndInit();
             this.ResumeLayout(false);
             this.PerformLayout();
 
@@ -413,8 +469,8 @@
         private System.Windows.Forms.Label label2;
         private MattControls.PictureBoxMaterial pictureBox2;
         private System.Windows.Forms.GroupBox groupBox2;
-        private System.Windows.Forms.RadioButton bitdepth1555;
-        private System.Windows.Forms.RadioButton bitdepth565;
+        private System.Windows.Forms.RadioButton abgr1555;
+        private System.Windows.Forms.RadioButton bgr565;
         private System.Windows.Forms.RadioButton bitdepth8;
         private System.Windows.Forms.GroupBox colormapGroup;
         private System.Windows.Forms.ComboBox gobColormap;
@@ -427,13 +483,15 @@
         private System.Windows.Forms.Button saveButton;
         private System.Windows.Forms.RadioButton bitdepthSolid;
         private System.Windows.Forms.Button originalKeepColormap;
-        private System.Windows.Forms.RadioButton bitdepth4444;
+        private System.Windows.Forms.RadioButton abgr4444;
         private System.Windows.Forms.Label originalNeedColormap;
         private System.Windows.Forms.Label previewNeedColormap;
         private System.Windows.Forms.CheckBox fillTransparent;
         public System.Windows.Forms.ListBox logList;
         private System.Windows.Forms.CheckBox autoselectFormat;
         private System.Windows.Forms.SplitContainer splitContainer1;
+        private System.Windows.Forms.RadioButton abgr32;
+        private System.Windows.Forms.RadioButton bgr24;
     }
 }
 

--- a/Matt.csproj
+++ b/Matt.csproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
@@ -8,7 +8,7 @@
     <OutputType>WinExe</OutputType>
     <RootNamespace>Matt</RootNamespace>
     <AssemblyName>Matt</AssemblyName>
-    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.7.1</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
     <Deterministic>true</Deterministic>

--- a/app.config
+++ b/app.config
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.7.1"/></startup>
+<System.Windows.Forms.ApplicationConfigurationSection>
+	<add key="DpiAwareness" value="PerMonitorV2"/>
+</System.Windows.Forms.ApplicationConfigurationSection>
+</configuration>


### PR DESCRIPTION
PR adds support to export MAT file in ABGR 4444, 24 bit BGR & 32 bit ABGR color format. Additional any RGB(A) color encodings up to 32 bit can be imported from MAT files. PR also fixes ABGR 1555 encoding, getting correct transparent color index from MAT record based on source code from [OpenJKDF2](https://github.com/shinyquagsire23/OpenJKDF2/blob/fa22d0fb8ffcab5a962dbf92a333bb4d8128f148/src/Engine/rdMaterial.c#L168-L169) and sets app DPI scaling to per monitor DPI awareness v2.